### PR TITLE
Disabling of individual jobs and improving the Class Name => Redis Namespace mapping

### DIFF
--- a/lib/sidetiq/api.rb
+++ b/lib/sidetiq/api.rb
@@ -93,6 +93,45 @@ module Sidetiq
       filter_set(Sidekiq::RetrySet.new, worker, &block)
     end
 
+    def disable(worker=nil)
+      workers = worker.nil? ? Sidetiq.workers : [worker]
+      keys=workers.map { |w| "sidetiq:#{Sidetiq.namespace(w)}:disabled" }
+      Sidekiq.redis do |redis|
+        keys.each do |key|
+          redis.set(key, 'true')
+        end
+      end
+    end
+
+    def enable(worker=nil)
+      workers = worker.nil? ? Sidetiq.workers : [worker]
+      keys=workers.map { |w| "sidetiq:#{Sidetiq.namespace(w)}:disabled" }
+      Sidekiq.redis do |redis|
+        keys.each do |key|
+          redis.del(key)
+        end
+      end
+    end
+
+    def namespace(object)
+      ns = case
+             when object.is_a?(Class)
+               object.name
+             when object.is_a?(String)
+               object
+             when object.is_a?(Symbol)
+               object
+             else
+               object.class.name
+           end
+      ns.gsub!('::', ':')
+      ns.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+      ns.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+      ns.tr!("-", "_")
+      ns.downcase!
+      ns
+    end
+
     private
 
     def filter_set(set, worker, &block)

--- a/lib/sidetiq/lock/redis.rb
+++ b/lib/sidetiq/lock/redis.rb
@@ -95,7 +95,7 @@ module Sidetiq
       def extract_key(key)
         case key
         when Class
-          "sidetiq:#{key.name}:lock"
+          "sidetiq:#{Sidetiq.namespace(key)}:lock"
         when String
           key.match(/sidetiq:(.+):lock/) ? key : "sidetiq:#{key}:lock"
         end

--- a/lib/sidetiq/middleware/history.rb
+++ b/lib/sidetiq/middleware/history.rb
@@ -39,7 +39,7 @@ module Sidetiq
 
       def save_entry_for_worker(entry, worker)
         Sidekiq.redis do |redis|
-          list_name = "sidetiq:#{worker.class.name}:history"
+          list_name = "sidetiq:#{Sidetiq.namespace(worker)}:history"
 
           redis.lpush(list_name, Sidekiq.dump_json(entry))
           redis.ltrim(list_name, 0, Sidetiq.config.worker_history - 1)

--- a/lib/sidetiq/schedulable.rb
+++ b/lib/sidetiq/schedulable.rb
@@ -56,15 +56,15 @@ module Sidetiq
       private
 
       def get_schedulable_keys
-        %w(next last schedule_description history).map { |key| "sidetiq:#{name}:#{key}" }
+        %w(next last schedule_description history).map { |key| "sidetiq:#{Sidetiq.namespace(name)}:#{key}" }
       end
 
       def get_schedulable_key(key)
-        Sidekiq.redis_pool.with { |r| r.get("sidetiq:#{name}:#{key}") }
+        Sidekiq.redis_pool.with { |r| r.get("sidetiq:#{Sidetiq.namespace(name)}:#{key}") }
       end
 
       def set_schedulable_key(key, value)
-        Sidekiq.redis_pool.with { |r| r.set("sidetiq:#{name}:#{key}", value) }
+        Sidekiq.redis_pool.with { |r| r.set("sidetiq:#{Sidetiq.namespace(name)}:#{key}", value) }
       end
 
       def get_timestamp(key)

--- a/lib/sidetiq/schedule.rb
+++ b/lib/sidetiq/schedule.rb
@@ -29,6 +29,15 @@ module Sidetiq
       end
     end
 
+    # Public: Checks if a job is disabled
+    #
+    # Returns true if a job is disabled, otherwise false.
+    def disabled?(worker)
+      Sidekiq.redis do |redis|
+        return redis.get("sidetiq:#{Sidetiq.namespace(worker)}:disabled") == 'true' ? true : false
+      end
+    end
+
     # Public: Checks if a job is due to be scheduled.
     #
     # Returns true if a job is due, otherwise false.

--- a/sidetiq.gemspec
+++ b/sidetiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'sidekiq',   '>= 3.0.0'
   gem.add_dependency 'celluloid', '>= 0.14.1'
-  gem.add_dependency 'ice_cube',  '0.11.1'
+  gem.add_dependency 'ice_cube',  '0.12.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sinatra'

--- a/sidetiq.gemspec
+++ b/sidetiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'sidekiq',   '>= 3.0.0'
   gem.add_dependency 'celluloid', '>= 0.14.1'
-  gem.add_dependency 'ice_cube',  '0.12.1'
+  gem.add_dependency 'ice_cube',  '>= 0.13.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sinatra'

--- a/test/test_history.rb
+++ b/test/test_history.rb
@@ -10,7 +10,7 @@ class TestHistory < Sidetiq::TestCase
     middlewared do; end
 
     entry = Sidekiq.redis do |redis|
-      redis.lrange('sidetiq:TestHistory::HistoryWorker:history', 0, -1)
+      redis.lrange('sidetiq:test_history:history_worker:history', 0, -1)
     end
 
     actual = Sidekiq.load_json(entry[0]).symbolize_keys
@@ -34,7 +34,7 @@ class TestHistory < Sidetiq::TestCase
     end
 
     entry = Sidekiq.redis do |redis|
-      redis.lrange('sidetiq:TestHistory::HistoryWorker:history', 0, -1)
+      redis.lrange('sidetiq:test_history:history_worker:history', 0, -1)
     end
 
     actual = Sidekiq.load_json(entry[0]).symbolize_keys

--- a/test/test_schedulable.rb
+++ b/test/test_schedulable.rb
@@ -1,7 +1,7 @@
 require_relative 'helper'
 require 'minitest/mock'
 
-class TestShedulable < Sidetiq::TestCase
+class TestSchedulable < Sidetiq::TestCase
   class FakeWorker
     include Sidetiq::Schedulable
   end
@@ -20,13 +20,13 @@ class TestShedulable < Sidetiq::TestCase
     end
   end
 
-  def test_resheduling
+  def test_rescheduling
     last_run = (Time.now - 100).to_f
     next_run = (Time.now + 100).to_f
 
     Sidekiq.redis do |redis|
-      redis.set "sidetiq:TestShedulable::FakeWorker:last", last_run
-      redis.set "sidetiq:TestShedulable::FakeWorker:next", next_run
+      redis.set "sidetiq:test_schedulable:fake_worker:last", last_run
+      redis.set "sidetiq:test_schedulable:fake_worker:next", next_run
     end
 
     assert FakeWorker.schedule_description == nil
@@ -39,8 +39,8 @@ class TestShedulable < Sidetiq::TestCase
     assert FakeWorker.next_scheduled_occurrence == -1.0
 
     Sidekiq.redis do |redis|
-      redis.set "sidetiq:TestShedulable::FakeWorker:last", last_run
-      redis.set "sidetiq:TestShedulable::FakeWorker:next", next_run
+      redis.set "sidetiq:test_schedulable:fake_worker:last", last_run
+      redis.set "sidetiq:test_schedulable:fake_worker:next", next_run
     end
 
     FakeWorker.schedule = nil

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -15,8 +15,8 @@ class TestWorker < Sidetiq::TestCase
     next_run = (Time.now + 100).to_f
 
     Sidekiq.redis do |redis|
-      redis.set "sidetiq:TestWorker::FakeWorker:last", last_run
-      redis.set "sidetiq:TestWorker::FakeWorker:next", next_run
+      redis.set "sidetiq:test_worker:fake_worker:last", last_run
+      redis.set "sidetiq:test_worker:fake_worker:next", next_run
     end
 
     assert FakeWorker.last_scheduled_occurrence == last_run


### PR DESCRIPTION
As a first step to the ability to enable/disable repeating sidetiq jobs, I've added a new check in handler that prevents the repeating job from firing if a "disabled" redis key is set.  Also created API methods to enable and disable all jobs.

I've also improve the class name to redis namespace mapping.  I have some of my worker classes namespaced and the default mapping was causing "ugly" redis namespacing.  Example
```
sidekiq:sidetiq::Worker::Repeat::TriggerDiscovery::locked
```
With my new approach the same key shows up in lowercase underscore and no double colons, as follows
```
sidekiq:sidetiq:worker:repeat:trigger_discovery:locked
```
If you're open to this PR, let me know if you'd like something changed or modified.