### PR TITLE
Display the runtime of each job on the history page

### DIFF
--- a/lib/sidetiq/middleware/history.rb
+++ b/lib/sidetiq/middleware/history.rb
@@ -13,6 +13,7 @@ module Sidetiq
 
       def call_with_sidetiq_history(worker, msg, queue)
         entry = new_history_entry
+        start_time = Time.now
 
         yield
       rescue StandardError => e
@@ -23,6 +24,7 @@ module Sidetiq
 
         raise e
       ensure
+        entry[:runtime] = (Time.now - start_time)
         save_entry_for_worker(entry, worker)
       end
 
@@ -33,7 +35,8 @@ module Sidetiq
           exception: "",
           backtrace: "",
           node: "#{Socket.gethostname}:#{Process.pid}-#{Thread.current.object_id}",
-          timestamp: Time.now.iso8601
+          timestamp: Time.now.iso8601,
+          runtime: ""
         }
       end
 

--- a/lib/sidetiq/views/history.erb
+++ b/lib/sidetiq/views/history.erb
@@ -17,6 +17,7 @@
         <thead>
           <th style="width: 10%">Status</th>
           <th style="width: 20%">Timestamp</th>
+          <th style="width: 10%">Runtime</th>
           <th>Details</th>
         </thead>
 
@@ -25,6 +26,7 @@
         <tr class="<%= 'error' if entry[:status] == 'failure' %>">
           <td><%= entry[:status].capitalize %></td>
           <td><%= Time.parse(entry[:timestamp]).strftime("%m/%d/%Y %I:%M:%S%p") %></td>
+          <td><%= entry[:runtime].round(3) %> s</td>
           <td>
             <% if entry[:status] == 'failure' %>
             <a class="backtrace" href="#" onclick="$(this).next().toggle(); return false">

--- a/test/test_history.rb
+++ b/test/test_history.rb
@@ -23,6 +23,7 @@ class TestHistory < Sidetiq::TestCase
 
     refute_empty actual[:node]
     refute_empty actual[:timestamp]
+    assert actual[:runtime] > 0
   end
 
   def test_failure
@@ -47,6 +48,7 @@ class TestHistory < Sidetiq::TestCase
 
     refute_empty actual[:node]
     refute_empty actual[:timestamp]
+    assert actual[:runtime] > 0
   end
 
   def middlewared


### PR DESCRIPTION
I wanted to get a sense of how long each of my jobs were running historically to help fine-tune my scheduling. I extended the history middleware to keep track of how long each job takes and store that along with the history entry, and then display it as a column in the history view.


![image](https://cloud.githubusercontent.com/assets/792845/4158697/644f1554-3491-11e4-9530-c9a01f7ae3b9.png)
