### PR TITLE
Bump ice_cube version to 0.12.1

### DIFF
--- a/sidetiq.gemspec
+++ b/sidetiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'sidekiq',   '>= 3.0.0'
   gem.add_dependency 'celluloid', '>= 0.14.1'
-  gem.add_dependency 'ice_cube',  '0.11.1'
+  gem.add_dependency 'ice_cube',  '0.12.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sinatra'


### PR DESCRIPTION
Ice_cube gem has been updated and the tests run perfectly using that. So, bump the requirement in gemspec.