### PR TITLE
Respect configured timezone in rails apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.6.4
+-----
+
+- Use Time.current instead of Time.now in rails apps to
+  respect configured timezone [effektz]
+
 0.6.3
 -----
 

--- a/lib/sidetiq/clock.rb
+++ b/lib/sidetiq/clock.rb
@@ -57,7 +57,7 @@ module Sidetiq
     #
     # Returns a Time instance.
     def gettime
-      Sidetiq.config.utc ? Time.now.utc : Time.now
+      Sidetiq.config.utc ? Time.now.utc : (Time.respond_to?(:current) ? Time.current : Time.now)
     end
   end
 end


### PR DESCRIPTION
This change will make sidekiq respect the set timezone inside of rails apps by using `Time.current` instead of `Time.now`