### PR TITLE
Send CSRF tokens with trigger and unlock actions

### DIFF
--- a/lib/sidetiq/views/locks.erb
+++ b/lib/sidetiq/views/locks.erb
@@ -36,6 +36,7 @@
           </td>
             <td>
               <form action="<%= "#{root_path}sidetiq/#{meta.key}/unlock" %>" method="post">
+                <%= csrf_tag %>
                 <input class="btn btn-danger btn-small" type="submit" name="trigger" value="Unlock" data-confirm="Are you sure you want remove this lock?" />
               </form>
             </td>

--- a/lib/sidetiq/views/sidetiq.erb
+++ b/lib/sidetiq/views/sidetiq.erb
@@ -37,6 +37,7 @@
             </td>
             <td>
               <form action="<%= "#{root_path}sidetiq/#{worker.name}/trigger" %>" method="post">
+                <%= csrf_tag %>
                 <input class="btn btn-danger btn-small" type="submit" name="trigger" value="Trigger" data-confirm="Are you sure you want to trigger this job?" />
               </form>
             </td>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,5 @@
+ENV['RACK_ENV'] ||= 'test'
+
 if RUBY_PLATFORM != "java"
   require 'coveralls'
   Coveralls.wear!


### PR DESCRIPTION
This is a PR for issue #138.

There were some failing tests in test/test_web.rb related to the CSRF token being absent. In order to fix this, I set RACK_ENV to test during the tests to disable `Rack::Protection` because that is what Sidekiq did in mperham/sidekiq@cf3c43b.
